### PR TITLE
Add www -> non-www redirect

### DIFF
--- a/test/weather-site.test.ts
+++ b/test/weather-site.test.ts
@@ -46,4 +46,60 @@ test('Verify resources are created', () => {
   })
 })
 
-// TODO test for stack with custom domain
+test('Verify resources are created with custom domain', () => {
+  const app = new App()
+  const stack = new WeatherSiteStack(app, 'CustomDomainStack', {
+    domainName: 'mydomain.com',
+    locationName: 'New York, NY USA',
+    openWeatherUrl: 'https://api.openweathermap.org/data/2.5/onecall',
+    schedules:
+      'cron(0/30 * * 6-9 ? *), cron(0/10 * * 1,2,3,4,5,10,11,12 ? *)'.split(
+        ', ',
+      ),
+    secretsExtensionArn: 'secret-extension-arn',
+    weatherLocationLat: '111',
+    weatherLocationLon: '222',
+    weatherSecretArn: 'weather-secret-arn',
+    weatherType: 'rain',
+  })
+  const template = Template.fromStack(stack)
+
+  template.resourceCountIs('AWS::S3::Bucket', 1)
+  template.resourceCountIs('AWS::SSM::Parameter', 1)
+  template.resourceCountIs('AWS::CloudFront::Distribution', 2)
+  template.resourceCountIs('AWS::Route53::RecordSet', 2)
+  template.resourceCountIs('AWS::CloudFront::Function', 1)
+
+  template.hasResourceProperties('AWS::CertificateManager::Certificate', {
+    DomainName: 'mydomain.com',
+  })
+  template.hasResourceProperties('AWS::CertificateManager::Certificate', {
+    DomainName: 'www.mydomain.com',
+  })
+  template.hasResourceProperties('AWS::Lambda::Function', {
+    FunctionName: 'CustomDomainStack-checkCurrentWeather',
+    Runtime: 'nodejs20.x',
+    Architectures: ['arm64'],
+  })
+  template.hasResourceProperties('AWS::Lambda::Function', {
+    FunctionName: 'CustomDomainStack-updateSiteFunction',
+    Runtime: 'nodejs20.x',
+    Architectures: ['arm64'],
+  })
+
+  template.hasResourceProperties('AWS::StepFunctions::StateMachine', {
+    StateMachineName: 'CustomDomainStack-state-machine',
+    StateMachineType: 'EXPRESS',
+    LoggingConfiguration: {
+      Level: 'ALL',
+    },
+  })
+  template.hasResourceProperties('AWS::Scheduler::Schedule', {
+    Name: 'CustomDomainStack-schedule-0',
+    ScheduleExpression: 'cron(0/30 * * 6-9 ? *)',
+  })
+  template.hasResourceProperties('AWS::Scheduler::Schedule', {
+    Name: 'CustomDomainStack-schedule-1',
+    ScheduleExpression: 'cron(0/10 * * 1,2,3,4,5,10,11,12 ? *)',
+  })
+})

--- a/test/weather-site.test.ts
+++ b/test/weather-site.test.ts
@@ -45,3 +45,5 @@ test('Verify resources are created', () => {
     ScheduleExpression: 'rate(10 minutes)',
   })
 })
+
+// TODO test for stack with custom domain


### PR DESCRIPTION
### Description
Not a huge fan of this solution, but apparently Route53 doesn't have a setting that allows you to do this in their DNS?

Implementing the solution described in [this helpful blog post](https://paramvirsingh.com/post/article/redirect-www-to-naked-domain-aws-cloudfront).

### Changes
- Split certificate out into two seperate ones (one for www and another for non-www)
- Add second CloudFront distro to handle www request
- Associate a viewer-request CF function to this distro that redirects to the non-www version
- A record to map www domain to this new CF distro
- Update original CF distro to remove the www alternative domain name
- Add test for a CDK stack with a custom domain