### PR TITLE
[Issue 9] Add optional email notifications when site status changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,9 @@ OPEN_WEATHER_URL=https://openweathermap.org/city/5731371
 # https://openweathermap.org/weather-conditions#Weather-Condition-Codes-2
 WEATHER_TYPE=snow
 # Optional env vars
-# ALERT_EMAIL=
+# Email address for notifications when site status changes or system failures occur
+# You must confirm the SNS subscription via email after deployment
+# ALERT_EMAIL=your-email@example.com
 # example.com (assuming non-www domain)
 # DOMAIN_NAME=
 # An optional prefix for your cloudformation stack name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,6 @@ jobs:
       - name: cdk synth custom domain stack
         run: npm run synth:quiet
         env:
-          ALERT_EMAIL: test@test.com
           LOCATION_NAME: Pittsburgh, Pennsylvania
           OPEN_WEATHER_URL: https://openweathermap.org/city/5206379
           SCHEDULES: 'rate(60 minutes)'

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -22,6 +22,7 @@ A serverless weather reporting website that answers a single question: "Is it [c
 - Weather data from OpenWeatherMap API only
 - Site updates are atomic: all files updated together or not at all
 - Graceful degradation: show last known status on API failures
+- Optional email notifications when status changes or system failures occur
 
 ## Deployment Options
 
@@ -62,6 +63,26 @@ A serverless weather reporting website that answers a single question: "Is it [c
 3. Compare against stored status in S3
 4. If changed, generate new HTML and upload to S3
 5. CloudFront serves updated content globally
+6. Optional: Send email notification via SNS when status changes
+
+## Notification Features (Optional)
+
+### Email Notifications
+
+When `ALERT_EMAIL` environment variable is configured:
+
+- **Status Change Notifications**: Email sent when weather condition status changes (YES ↔ NO)
+- **System Failure Alerts**: CloudWatch alarms trigger email notifications for Step Function failures
+- **SNS Integration**: Uses AWS SNS with email subscription (requires user confirmation)
+- **Failure Threshold**: Alarm triggers on ≥2 Step Function failures within 1 hour
+
+### Notification Requirements
+
+- Email notifications must not impact site performance
+- Notifications are completely optional - site works without them
+- User must confirm SNS email subscription after deployment
+- Alert stack is conditionally created only when `ALERT_EMAIL` is set
+- Notifications should include relevant context (location, status, timestamp)
 
 ## Development Constraints
 
@@ -78,6 +99,7 @@ A serverless weather reporting website that answers a single question: "Is it [c
 - Log all errors to CloudWatch for debugging
 - Fallback to last known good status on failures
 - Include health checks for monitoring stack
+- Optional email alerts for system failures via CloudWatch alarms
 
 ### Performance
 

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -33,7 +33,7 @@ test/          # Jest tests with CDK snapshot testing
 
 - **Main stack**: S3 bucket + CloudFront + Step Functions + Lambda (always required)
 - **Domain stack**: Route53 hosted zone + SSL certificates + www redirect (optional - only for custom domains)
-- **Alert stack**: CloudWatch alarms + SNS (optional)
+- **Alert stack**: CloudWatch alarms + SNS for email notifications (optional - only when ALERT_EMAIL is set)
 - Environment validation required in `bin/weather-site.ts`
 - Use CDK app for stack dependency management
 
@@ -51,6 +51,7 @@ The domain stack is only needed when using a custom domain:
 - Consistent naming: `${stackPrefix}-${resource-type}`
 - Environment variables validated at startup
 - Secrets in AWS Secrets Manager: `weather-site-api-key`
+- Optional email notifications via SNS when `ALERT_EMAIL` is configured
 - ARM64 Lambda architecture with esbuild bundling
 
 ### Code Patterns

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -40,6 +40,7 @@ inclusion: always
 
 - Environment variables validated at CDK app startup
 - OpenWeatherMap API key stored in AWS Secrets Manager as `weather-site-api-key`
+- Optional `ALERT_EMAIL` environment variable for email notifications
 - Local development: copy `.env.example` to `.env`
 - Never commit secrets to version control
 
@@ -73,7 +74,7 @@ npm run deploy:ci # CI/CD deployment (no prompts)
 
 - **Weather Stack**: Main application stack (S3, CloudFront, Lambda, Step Functions)
 - **Domain Stack**: Optional custom domain stack (Route53, SSL certificates, redirects)
-- **Alert Stack**: Optional monitoring stack (CloudWatch alarms, SNS)
+- **Alert Stack**: Optional monitoring stack (CloudWatch alarms, SNS for email notifications)
 
 ### Regional Deployment Requirements
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ My deployment of this site is [here](https://isitsnowinginhillsboro.com/) 🚀
 ### 📈 Optional Monitoring Stack
 
 - **👀 CloudWatch** - Alarms for Step Function failures
-- **📧 SNS** - Email notifications
+- **📧 SNS** - Email notifications for site status changes and system failures
 
 ### 🛠️ Technologies
 
@@ -89,7 +89,7 @@ Requires additional domain stack deployed to `us-east-1` region for SSL certific
    ```
 
    - Set required variables: `WEATHER_LOCATION_LAT`, `WEATHER_LOCATION_LON`, `LOCATION_NAME`, etc.
-   - Optionally set `ALERT_EMAIL` for failure notifications 📧
+   - Optionally set `ALERT_EMAIL` for email notifications when site status changes or system failures occur 📧
    - Leave `DOMAIN_NAME` empty for basic deployment
 
 4. 📦 Install dependencies:
@@ -195,7 +195,7 @@ Configure in `.env` file:
 - ⏰ `SCHEDULES` - Cron expressions for check frequency
 - 🏷️ `STACK_PREFIX` - Prefix for all AWS resources
 - 🌐 `DOMAIN_NAME` - Optional custom domain
-- 📧 `ALERT_EMAIL` - Optional email for failure notifications
+- 📧 `ALERT_EMAIL` - Optional email for notifications when site status changes or system failures occur
 
 ### 🧪 Testing
 
@@ -204,6 +204,59 @@ Basic CDK snapshot tests are in the `test/` folder:
 ```bash
 npm run test
 ```
+
+## 📧 Email Notifications (Optional)
+
+The weather site supports optional email notifications for two scenarios:
+
+### 🔄 Status Change Notifications
+
+When the weather condition status changes (e.g., from "NO" to "YES" or vice versa), you'll receive an email notification with the new status.
+
+### ⚠️ System Failure Alerts
+
+If the Step Function fails (e.g., API errors, deployment issues), you'll receive CloudWatch alarm notifications.
+
+### 🛠️ Setup
+
+1. Add your email address to the `.env` file:
+
+   ```bash
+   ALERT_EMAIL=your-email@example.com
+   ```
+
+2. Deploy the weather stack and alert stack:
+
+   ```bash
+   npm run deploy
+   ```
+
+   Or deploy them separately:
+
+   ```bash
+   npm run cdk deploy -- --exclusively "*-weather"
+   npm run cdk deploy -- --exclusively "*-alert"
+   ```
+
+3. **Important**: You will receive two confirmation emails from AWS SNS that you must confirm by clicking the links:
+   - One for status change notifications (from the weather stack)
+   - One for system failure alerts (from the alert stack)
+
+### 📊 What Gets Created
+
+- **📧 SNS Topic** - Handles email delivery
+- **👀 CloudWatch Alarm** - Monitors Step Function failures (≥2 failures in 1 hour)
+- **📬 Email Subscription** - Sends notifications to your specified email
+
+### 🗑️ Removing Email Notifications
+
+To stop receiving emails:
+
+1. Remove `ALERT_EMAIL` from `.env`
+2. Redeploy the weather stack: `npm run cdk deploy -- --exclusively "*-weather"`
+3. Destroy the alert stack: `npm run cdk destroy -- --exclusively "*-alert"`
+
+This removes both the status change notifications (weather stack) and system failure alerts (alert stack).
 
 ## 🧹 Cleanup
 

--- a/bin/weather-site.ts
+++ b/bin/weather-site.ts
@@ -70,6 +70,7 @@ const weatherSiteStack = new WeatherSiteStack(app, `${stackPrefix}-weather`, {
   description: `Resources for ${stackPrefix}-weather, an informative weather website`,
   env: { account, region },
   crossRegionReferences: region === 'us-east-1' ? undefined : true,
+  alertEmail,
   certificate: domainStack?.certificate,
   domainName,
   hostedZone: domainStack?.hostedZone,

--- a/lib/alert-stack.ts
+++ b/lib/alert-stack.ts
@@ -24,7 +24,7 @@ export class AlertStack extends Stack {
     const topicName = `${this.id}-error-topic`
     const errorTopic = new Topic(this, topicName, {
       topicName,
-      displayName: `Weather Site Topic for ${this.id}`,
+      displayName: `Weather Site Error Topic for ${this.id}`,
     })
     errorTopic.addSubscription(
       new EmailSubscription(alertEmail, {

--- a/test/__snapshots__/weather-site.test.ts.snap
+++ b/test/__snapshots__/weather-site.test.ts.snap
@@ -1079,7 +1079,7 @@ exports[`Custom domain resources Verify weather stack with custom domain 1`] = `
           "Arn": {
             "Ref": "TestWeatherStackstatemachine71961157",
           },
-          "Input": "{"WEATHER_TYPE":"rain","WEATHER_LOCATION_LAT":"111","WEATHER_LOCATION_LON":"222"}",
+          "Input": "{"WEATHER_TYPE":"rain","WEATHER_LOCATION_LAT":"111","WEATHER_LOCATION_LON":"222","STACK_NAME":"TestWeatherStack"}",
           "RetryPolicy": {
             "MaximumEventAgeInSeconds": 90,
             "MaximumRetryAttempts": 2,
@@ -1108,7 +1108,7 @@ exports[`Custom domain resources Verify weather stack with custom domain 1`] = `
           "Arn": {
             "Ref": "TestWeatherStackstatemachine71961157",
           },
-          "Input": "{"WEATHER_TYPE":"rain","WEATHER_LOCATION_LAT":"111","WEATHER_LOCATION_LON":"222"}",
+          "Input": "{"WEATHER_TYPE":"rain","WEATHER_LOCATION_LAT":"111","WEATHER_LOCATION_LON":"222","STACK_NAME":"TestWeatherStack"}",
           "RetryPolicy": {
             "MaximumEventAgeInSeconds": 90,
             "MaximumRetryAttempts": 2,
@@ -1599,7 +1599,7 @@ exports[`Custom domain resources Verify weather stack with custom domain 1`] = `
 }
 `;
 
-exports[`Non-custom domain resources Verify alert stack resources 1`] = `
+exports[`Non-custom domain resources Verify error alert stack resources 1`] = `
 {
   "Parameters": {
     "BootstrapVersion": {
@@ -1639,7 +1639,7 @@ exports[`Non-custom domain resources Verify alert stack resources 1`] = `
     },
     "TestAlertStackerrortopic8CC68A85": {
       "Properties": {
-        "DisplayName": "Weather Site Topic for TestAlertStack",
+        "DisplayName": "Weather Site Error Topic for TestAlertStack",
         "TopicName": "TestAlertStack-error-topic",
       },
       "Type": "AWS::SNS::Topic",
@@ -2439,7 +2439,7 @@ exports[`Non-custom domain resources Verify weather stack resources 1`] = `
           "Arn": {
             "Ref": "MyTestStackstatemachineF5D307B4",
           },
-          "Input": "{"WEATHER_TYPE":"snow","WEATHER_LOCATION_LAT":"123","WEATHER_LOCATION_LON":"456"}",
+          "Input": "{"WEATHER_TYPE":"snow","WEATHER_LOCATION_LAT":"123","WEATHER_LOCATION_LON":"456","STACK_NAME":"MyTestStack"}",
           "RetryPolicy": {
             "MaximumEventAgeInSeconds": 90,
             "MaximumRetryAttempts": 2,
@@ -2520,7 +2520,15 @@ exports[`Non-custom domain resources Verify weather stack resources 1`] = `
               {
                 "Ref": "AWS::Partition",
               },
-              ":states:::aws-sdk:cloudfront:createInvalidation"}}}]},"Site is up to date":{"Type":"Pass","QueryLanguage":"JSONata","Comment":"The final state","Output":{"SiteStatus":"{% $CurrentWeather %}"},"End":true},"Site update failure":{"Type":"Fail"}}}",
+              ":states:::aws-sdk:cloudfront:createInvalidation"}}},{"StartAt":"Send email notification of site status change","States":{"Send email notification of site status change":{"QueryLanguage":"JSONata","End":true,"Type":"Task","Arguments":{"TopicArn":"",
+              {
+                "Ref": "MyTestStacktopic278AF978",
+              },
+              "","Subject":"{% $states.context.Execution.Input.STACK_NAME & \\" status change\\" %}","Message":"{% $states.context.Execution.Input.STACK_NAME & \\" changed from \\" & $SiteStatus & \\" to \\" & $CurrentWeather & \\".\\" %}"},"Output":{},"Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::aws-sdk:sns:publish"}}}]},"Site is up to date":{"Type":"Pass","QueryLanguage":"JSONata","Comment":"The final state","Output":{"SiteStatus":"{% $CurrentWeather %}"},"End":true},"Site update failure":{"Type":"Fail"}}}",
             ],
           ],
         },
@@ -2709,6 +2717,13 @@ exports[`Non-custom domain resources Verify weather stack resources 1`] = `
               },
             },
             {
+              "Action": "sns:publish",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "MyTestStacktopic278AF978",
+              },
+            },
+            {
               "Action": [
                 "logs:CreateLogDelivery",
                 "logs:GetLogDelivery",
@@ -2752,6 +2767,23 @@ exports[`Non-custom domain resources Verify weather stack resources 1`] = `
         "Value": "Initial value",
       },
       "Type": "AWS::SSM::Parameter",
+    },
+    "MyTestStacktopic278AF978": {
+      "Properties": {
+        "DisplayName": "Weather Site State Change Topic for MyTestStack",
+        "TopicName": "MyTestStack-topic",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "MyTestStacktopictestexamplecomABC532A0": {
+      "Properties": {
+        "Endpoint": "test@example.com",
+        "Protocol": "email",
+        "TopicArn": {
+          "Ref": "MyTestStacktopic278AF978",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
     },
     "MyTestStackupdateSiteFunction705B529B": {
       "DependsOn": [


### PR DESCRIPTION
### Summary

These changes add an optional email notification for when the site status changes. It is tied to setting the `ALERT_EMAIL` environment variable.

### TODO

- [ ] update CI
- [ ] update tests
- [ ] update docs
- [ ] update screenshot in README