### PR TITLE
Replace dotenv with Node's built-in `--env-file-if-exists` flag and validate env vars with Zod

### DIFF
--- a/bin/weather-site.ts
+++ b/bin/weather-site.ts
@@ -1,51 +1,39 @@
 #!/usr/bin/env node
-import 'dotenv/config'
-
 import { App } from 'aws-cdk-lib'
+import { z } from 'zod'
 
 import { DomainStack } from '../lib/domain-stack'
 import { WeatherSiteStack } from '../lib/weather-site-stack'
 
-// Env var validation
-const {
-  AWS_DEFAULT_ACCOUNT_ID,
-  AWS_DEFAULT_REGION,
-  CDK_DEFAULT_ACCOUNT,
-  CDK_DEFAULT_REGION,
-  ALERT_EMAIL: alertEmail = undefined,
-  DOMAIN_NAME: domainName = undefined,
-  LOCATION_NAME: locationName = '',
-  OPEN_WEATHER_URL: openWeatherUrl = '',
-  SCHEDULES: schedules = 'rate(10 minutes)',
-  STACK_PREFIX: stackPrefix = 'myStack',
-  WEATHER_LOCATION_LAT: weatherLocationLat = '',
-  WEATHER_LOCATION_LON: weatherLocationLon = '',
-  WEATHER_TYPE: weatherType = 'snow',
-} = process.env
+const envSchema = z
+  .object({
+    CDK_DEFAULT_ACCOUNT: z.string().optional(),
+    CDK_DEFAULT_REGION: z.string().optional(),
+    AWS_DEFAULT_ACCOUNT_ID: z.string().optional(),
+    AWS_DEFAULT_REGION: z.string().optional(),
+    ALERT_EMAIL: z.email().optional(),
+    DOMAIN_NAME: z.string().min(1).optional(),
+    LOCATION_NAME: z.string().min(1, 'LOCATION_NAME is required'),
+    OPEN_WEATHER_URL: z.url('OPEN_WEATHER_URL must be a valid URL'),
+    SCHEDULES: z.string().default('rate(10 minutes)'),
+    STACK_PREFIX: z.string().default('myStack'),
+    WEATHER_LOCATION_LAT: z.string().min(1, 'WEATHER_LOCATION_LAT is required'),
+    WEATHER_LOCATION_LON: z.string().min(1, 'WEATHER_LOCATION_LON is required'),
+    WEATHER_TYPE: z.string().default('snow'),
+  })
+  .refine((data) => data.CDK_DEFAULT_ACCOUNT || data.AWS_DEFAULT_ACCOUNT_ID, {
+    message:
+      'AWS account not found. Configure AWS CLI credentials or set AWS_DEFAULT_ACCOUNT_ID.',
+  })
+  .refine((data) => data.CDK_DEFAULT_REGION || data.AWS_DEFAULT_REGION, {
+    message:
+      'AWS region not found. Configure AWS CLI credentials or set AWS_DEFAULT_REGION.',
+  })
 
-const account = CDK_DEFAULT_ACCOUNT || AWS_DEFAULT_ACCOUNT_ID
-const region = CDK_DEFAULT_REGION || AWS_DEFAULT_REGION
+const env = envSchema.parse(process.env)
 
-if (
-  ![locationName, openWeatherUrl, weatherLocationLat, weatherLocationLon].every(
-    (el) => !!el,
-  )
-) {
-  // eslint-disable-next-line no-console
-  console.log(
-    JSON.stringify(
-      {
-        locationName,
-        openWeatherUrl,
-        weatherLocationLat,
-        weatherLocationLon,
-      },
-      null,
-      2,
-    ),
-  )
-  throw new Error('Missing environment variables!')
-}
+const account = (env.CDK_DEFAULT_ACCOUNT || env.AWS_DEFAULT_ACCOUNT_ID)!
+const region = (env.CDK_DEFAULT_REGION || env.AWS_DEFAULT_REGION)!
 
 const app = new App()
 
@@ -55,27 +43,27 @@ const app = new App()
  * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cnames-and-https-requirements.html#https-requirements-aws-region
  */
 let domainStack
-if (domainName) {
-  domainStack = new DomainStack(app, `${stackPrefix}-domain`, {
-    description: ` Resources needed to have a custom domain for on ${stackPrefix}-weather`,
+if (env.DOMAIN_NAME) {
+  domainStack = new DomainStack(app, `${env.STACK_PREFIX}-domain`, {
+    description: ` Resources needed to have a custom domain for on ${env.STACK_PREFIX}-weather`,
     crossRegionReferences: true,
     env: { account, region: 'us-east-1' },
-    domainName,
+    domainName: env.DOMAIN_NAME,
   })
 }
 
-new WeatherSiteStack(app, `${stackPrefix}-weather`, {
-  description: `Resources for ${stackPrefix}-weather, an informative weather website`,
+new WeatherSiteStack(app, `${env.STACK_PREFIX}-weather`, {
+  description: `Resources for ${env.STACK_PREFIX}-weather, an informative weather website`,
   env: { account, region },
   crossRegionReferences: region === 'us-east-1' ? undefined : true,
-  alertEmail,
+  alertEmail: env.ALERT_EMAIL,
   certificate: domainStack?.certificate,
-  domainName,
+  domainName: env.DOMAIN_NAME,
   hostedZone: domainStack?.hostedZone,
-  locationName,
-  openWeatherUrl,
-  schedules: schedules.split(', '),
-  weatherLocationLat,
-  weatherLocationLon,
-  weatherType,
+  locationName: env.LOCATION_NAME,
+  openWeatherUrl: env.OPEN_WEATHER_URL,
+  schedules: env.SCHEDULES.split(', '),
+  weatherLocationLat: env.WEATHER_LOCATION_LAT,
+  weatherLocationLon: env.WEATHER_LOCATION_LON,
+  weatherType: env.WEATHER_TYPE,
 })

--- a/cdk.json
+++ b/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "npx tsx bin/weather-site.ts",
+  "app": "node --env-file-if-exists=.env --import tsx bin/weather-site.ts",
   "watch": {
     "include": ["**"],
     "exclude": [

--- a/lib/weather-site-stack.ts
+++ b/lib/weather-site-stack.ts
@@ -213,18 +213,20 @@ export class WeatherSiteStack extends Stack {
     const updateSiteFunction = new NodejsFunction(this, updateSiteFuncId, {
       functionName: updateSiteFuncId,
       runtime: Runtime.NODEJS_24_X,
-      entry: 'dist/src/functions/update-site.js',
+      entry: 'src/functions/update-site.ts',
+      bundling: { sourceMap: true },
       loggingFormat: LoggingFormat.JSON,
       logGroup: updateSiteLogGroup,
       tracing: Tracing.ACTIVE,
       architecture: Architecture.ARM_64,
       timeout: Duration.seconds(30),
-      memorySize: 3008,
+      memorySize: 512,
       environment: {
         BUCKET_NAME: this.bucket.bucketName,
         LOCATION_NAME: this.props.locationName,
         OPEN_WEATHER_URL: this.props.openWeatherUrl,
         WEATHER_TYPE: this.props.weatherType,
+        NODE_OPTIONS: '--enable-source-maps',
       },
     })
     this.bucket.grantWrite(updateSiteFunction)

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,16 +19,16 @@
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.3.2",
         "aws-cdk": "^2.1108.0",
-        "dotenv": "^17.3.1",
-        "esbuild": "^0.27.2",
+        "esbuild": "^0.27.3",
         "eslint": "^10.0.2",
         "eslint-plugin-simple-import-sort": "^12.1.1",
-        "globals": "^17.0.0",
+        "globals": "^17.3.0",
         "prettier": "^3.8.1",
         "tsx": "^4.21.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.56.1",
-        "vitest": "^4.0.18"
+        "vitest": "^4.0.18",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
@@ -3582,19 +3582,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
@@ -4841,6 +4828,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,27 +5,25 @@
     "weather-site": "bin/weather-site.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --noEmit",
     "cdk": "cdk",
-    "clean": "rm -rf dist",
-    "deploy": "npm run clean && npm run build && npm run cdk deploy -- --all",
-    "deploy:ci": "npm run clean && npm run build && npm run cdk deploy -- --all --require-approval never",
+    "deploy": "npm run cdk deploy -- --all",
+    "deploy:ci": "npm run cdk deploy -- --all --require-approval never",
     "destroy": "npm run cdk destroy -- --all",
     "diff": "npm run cdk diff -- --all",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "format:ci": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "lint": "eslint --fix",
     "lint:ci": "eslint --quiet",
-    "synth": "npm run build && npm run cdk synth",
-    "synth:quiet": "npm run build && npm run cdk synth -- -q",
+    "synth": "npm run cdk synth",
+    "synth:quiet": "npm run cdk synth -- -q",
     "test": "vitest run",
-    "watch": "tsc -w"
+    "watch": "tsc -w --noEmit"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.3.2",
     "aws-cdk": "^2.1108.0",
-    "dotenv": "^17.3.1",
     "esbuild": "^0.27.3",
     "eslint": "^10.0.2",
     "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -34,7 +32,8 @@
     "tsx": "^4.21.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.56.1",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "zod": "^4.3.6"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1000.0",

--- a/test/__snapshots__/custom-domain.test.ts.snap
+++ b/test/__snapshots__/custom-domain.test.ts.snap
@@ -261,7 +261,7 @@ exports[`Custom domain resources > Verify weather stack with custom domain no no
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3423a042b818e31c1e34a19d6689ab2e5f9b70fcbe9e71df66f241b20a200bd9.zip",
+          "S3Key": "[ASSET_HASH].zip",
         },
         "Environment": {
           "Variables": {
@@ -424,7 +424,7 @@ exports[`Custom domain resources > Verify weather stack with custom domain no no
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6.zip",
+          "S3Key": "[ASSET_HASH].zip",
         },
         "Description": {
           "Fn::Join": [
@@ -815,7 +815,7 @@ exports[`Custom domain resources > Verify weather stack with custom domain no no
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0cfdecad2260a3a84ad0c2d08a77e03c9d25e26c7b52f26b1e1faf97aef92f18.zip",
+          "S3Key": "[ASSET_HASH].zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -841,7 +841,7 @@ exports[`Custom domain resources > Verify weather stack with custom domain no no
           },
         ],
         "SourceObjectKeys": [
-          "5dd6e66aca7809028d3677a67f96628aaa6a67242456ee0f3c81ba4842f6afb0.zip",
+          "[ASSET_HASH].zip",
         ],
         "WaitForDistributionInvalidation": true,
       },
@@ -1218,7 +1218,7 @@ exports[`Custom domain resources > Verify weather stack with custom domain no no
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "aac6bbfae1c334a8f3241d7f548703f07d7ced61a888e15c8a319af37837bebd.zip",
+          "S3Key": "[ASSET_HASH].zip",
         },
         "Environment": {
           "Variables": {

--- a/test/__snapshots__/custom-domain.test.ts.snap
+++ b/test/__snapshots__/custom-domain.test.ts.snap
@@ -1218,7 +1218,7 @@ exports[`Custom domain resources > Verify weather stack with custom domain no no
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "313c414123890f4474c3395bc901602ffcbfea48931d27b5934b574ae5101d6b.zip",
+          "S3Key": "aac6bbfae1c334a8f3241d7f548703f07d7ced61a888e15c8a319af37837bebd.zip",
         },
         "Environment": {
           "Variables": {
@@ -1226,6 +1226,7 @@ exports[`Custom domain resources > Verify weather stack with custom domain no no
               "Ref": "TestWeatherStackbucket354D63DD",
             },
             "LOCATION_NAME": "New York, NY USA",
+            "NODE_OPTIONS": "--enable-source-maps",
             "OPEN_WEATHER_URL": "https://api.openweathermap.org/data/2.5/onecall",
             "WEATHER_TYPE": "rain",
           },
@@ -1238,7 +1239,7 @@ exports[`Custom domain resources > Verify weather stack with custom domain no no
             "Ref": "TestWeatherStackupdateSiteLogGroupD038D61C",
           },
         },
-        "MemorySize": 3008,
+        "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
             "TestWeatherStackupdateSiteFunctionServiceRole997D6557",

--- a/test/__snapshots__/notifications.test.ts.snap
+++ b/test/__snapshots__/notifications.test.ts.snap
@@ -899,7 +899,7 @@ exports[`Weather stack with notifications > Verify weather stack resources with 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "313c414123890f4474c3395bc901602ffcbfea48931d27b5934b574ae5101d6b.zip",
+          "S3Key": "aac6bbfae1c334a8f3241d7f548703f07d7ced61a888e15c8a319af37837bebd.zip",
         },
         "Environment": {
           "Variables": {
@@ -907,6 +907,7 @@ exports[`Weather stack with notifications > Verify weather stack resources with 
               "Ref": "MyTestStackbucketE9C89BC4",
             },
             "LOCATION_NAME": "Test Location",
+            "NODE_OPTIONS": "--enable-source-maps",
             "OPEN_WEATHER_URL": "https://api.openweathermap.org/data/2.5/onecall",
             "WEATHER_TYPE": "snow",
           },
@@ -919,7 +920,7 @@ exports[`Weather stack with notifications > Verify weather stack resources with 
             "Ref": "MyTestStackupdateSiteLogGroup7C127C90",
           },
         },
-        "MemorySize": 3008,
+        "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
             "MyTestStackupdateSiteFunctionServiceRole9D67F132",

--- a/test/__snapshots__/notifications.test.ts.snap
+++ b/test/__snapshots__/notifications.test.ts.snap
@@ -31,7 +31,7 @@ exports[`Weather stack with notifications > Verify weather stack resources with 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3423a042b818e31c1e34a19d6689ab2e5f9b70fcbe9e71df66f241b20a200bd9.zip",
+          "S3Key": "[ASSET_HASH].zip",
         },
         "Environment": {
           "Variables": {
@@ -194,7 +194,7 @@ exports[`Weather stack with notifications > Verify weather stack resources with 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6.zip",
+          "S3Key": "[ASSET_HASH].zip",
         },
         "Description": {
           "Fn::Join": [
@@ -493,7 +493,7 @@ exports[`Weather stack with notifications > Verify weather stack resources with 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0cfdecad2260a3a84ad0c2d08a77e03c9d25e26c7b52f26b1e1faf97aef92f18.zip",
+          "S3Key": "[ASSET_HASH].zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -519,7 +519,7 @@ exports[`Weather stack with notifications > Verify weather stack resources with 
           },
         ],
         "SourceObjectKeys": [
-          "5dd6e66aca7809028d3677a67f96628aaa6a67242456ee0f3c81ba4842f6afb0.zip",
+          "[ASSET_HASH].zip",
         ],
         "WaitForDistributionInvalidation": true,
       },
@@ -899,7 +899,7 @@ exports[`Weather stack with notifications > Verify weather stack resources with 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "aac6bbfae1c334a8f3241d7f548703f07d7ced61a888e15c8a319af37837bebd.zip",
+          "S3Key": "[ASSET_HASH].zip",
         },
         "Environment": {
           "Variables": {

--- a/test/custom-domain.test.ts
+++ b/test/custom-domain.test.ts
@@ -3,6 +3,7 @@ import { Match, Template } from 'aws-cdk-lib/assertions'
 
 import { DomainStack } from '../lib/domain-stack'
 import { WeatherSiteStack } from '../lib/weather-site-stack'
+import { sanitizeAssetHashes } from './test-utils'
 
 describe('Custom domain resources', () => {
   test('Verify domain stack resources', () => {
@@ -34,7 +35,7 @@ describe('Custom domain resources', () => {
       Type: 'A',
     })
 
-    expect(template.toJSON()).toMatchSnapshot()
+    expect(sanitizeAssetHashes(template.toJSON())).toMatchSnapshot()
   })
 
   test('Verify weather stack with custom domain no notifications', () => {
@@ -115,6 +116,6 @@ describe('Custom domain resources', () => {
       Match.not(Match.objectLike({ AlarmActions: Match.anyValue() })),
     )
 
-    expect(template.toJSON()).toMatchSnapshot()
+    expect(sanitizeAssetHashes(template.toJSON())).toMatchSnapshot()
   })
 })

--- a/test/notifications.test.ts
+++ b/test/notifications.test.ts
@@ -2,6 +2,7 @@ import { App } from 'aws-cdk-lib'
 import { Template } from 'aws-cdk-lib/assertions'
 
 import { WeatherSiteStack } from '../lib/weather-site-stack'
+import { sanitizeAssetHashes } from './test-utils'
 
 describe('Weather stack with notifications', () => {
   test('Verify weather stack resources with notifications', () => {
@@ -59,6 +60,6 @@ describe('Weather stack with notifications', () => {
       },
     })
 
-    expect(template.toJSON()).toMatchSnapshot()
+    expect(sanitizeAssetHashes(template.toJSON())).toMatchSnapshot()
   })
 })

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,0 +1,12 @@
+export function sanitizeAssetHashes(obj: unknown): unknown {
+  if (typeof obj === 'string' && /^[a-f0-9]{64}\.zip$/.test(obj)) {
+    return '[ASSET_HASH].zip'
+  }
+  if (Array.isArray(obj)) return obj.map(sanitizeAssetHashes)
+  if (obj && typeof obj === 'object') {
+    return Object.fromEntries(
+      Object.entries(obj).map(([k, v]) => [k, sanitizeAssetHashes(v)]),
+    )
+  }
+  return obj
+}


### PR DESCRIPTION
Swaps out `dotenv` for Node's native env file loading (`--env-file-if-exists=.env`) and replaces the hand-rolled environment variable checks with a Zod schema. This gives proper validation with useful error messages (e.g. checking that `OPEN_WEATHER_URL` is a valid URL, `ALERT_EMAIL` is a valid email) instead of just checking for truthiness.

Also:
- Switch the update-site Lambda to use `esbuild` bundling directly from TypeScript source instead of pre-compiled JS, with source maps enabled
- Drop memory from 3008 MB to 512 MB for the update-site function
- Change `tsc` to `--noEmit` since esbuild handles the actual compilation now
- Remove the `clean` script and the build steps from `deploy`/`synth` commands since they're no longer needed
- Update snapshots to reflect the Lambda changes

fixes #48 